### PR TITLE
Update asciidoctor-pdf version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'json'
 gem 'awesome_print'
 
 gem 'asciidoctor-epub3', '1.0.0.alpha.2'
-gem 'asciidoctor-pdf', '1.5.0.alpha.5'
+gem 'asciidoctor-pdf', '1.5.0.alpha.12'
 
 gem 'coderay'
 gem 'pygments.rb'


### PR DESCRIPTION
Update to 1.5.0.alpha.12 because of missing international characters (https://github.com/asciidoctor/asciidoctor-pdf/issues/72)
